### PR TITLE
Update allowed_hosts.txt

### DIFF
--- a/allowed_hosts.txt
+++ b/allowed_hosts.txt
@@ -4,6 +4,7 @@ wcc.sc.egov.usda.gov
 cdec.water.ca.gov
 climate.arizona.edu
 data.rcc-acis.org
+grid2.rcc-acis.org
 cds.climate.copernicus.eu
 *.copernicus-climate.eu
 hydro1.gesdisc.eosdis.nasa.gov


### PR DESCRIPTION
Some RCC-ACIS endpoints are at the grid2.rcc-acis.org domain, as opposed to data.rcc-acis.org.